### PR TITLE
Introduce filter categories with options page

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,20 +1,27 @@
 (() => {
-  const triggers = [
-    'slachtoffer','vermoord','opgelicht','dood',
-    'aanval','aanslag','corruptie','zedenzaak',
-    'verkrachting','misbruik','geweld'
-  ];
+  const categories = {
+    violence: ['slachtoffer', 'vermoord', 'aanval', 'aanslag', 'geweld', 'dood'],
+    corruption: ['corruptie', 'opgelicht'],
+    sexual: ['zedenzaak', 'verkrachting', 'misbruik']
+  };
+
+  const defaults = { violence: true, corruption: true, sexual: true };
   const placeholder = 'Dit is een ongezond artikel';
 
-  // zoek alle tekst­houdende elementen
-  const elems = document.querySelectorAll('article, p, h1, h2, h3');
-  elems.forEach(el => {
-    const text = el.innerText.toLowerCase();
-    if (triggers.some(t => text.includes(t))) {
-      const w = document.createElement('div');
-      w.style.cssText = 'background:#eee;color:#333;padding:1em;border:1px solid #ccc;margin:1em 0;';
-      w.innerText = placeholder;
-      el.replaceWith(w);
-    }
+  chrome.storage.sync.get(defaults, prefs => {
+    const triggers = Object.entries(categories)
+      .filter(([cat]) => prefs[cat])
+      .flatMap(([, words]) => words);
+
+    const elems = document.querySelectorAll('article, p, h1, h2, h3');
+    elems.forEach(el => {
+      const text = el.innerText.toLowerCase();
+      if (triggers.some(t => text.includes(t))) {
+        const w = document.createElement('div');
+        w.style.cssText = 'background:#eee;color:#333;padding:1em;border:1px solid #ccc;margin:1em 0;';
+        w.innerText = placeholder;
+        el.replaceWith(w);
+      }
+    });
   });
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -12,5 +12,6 @@
       "js": ["content.js"],
       "run_at": "document_end"
     }
-  ]
+  ],
+  "options_page": "options.html"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -13,5 +13,8 @@
       "run_at": "document_end"
     }
   ],
-  "options_page": "options.html"
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  }
 }

--- a/options.html
+++ b/options.html
@@ -15,7 +15,7 @@
   <label><input type="checkbox" name="sexual"> Zedenzaken</label>
   <label><input type="checkbox" name="corruption"> Corruptie</label>
 </form>
-<button id="save">Opslaan</button>
+<button id="save" type="button">Opslaan</button>
 <p id="status"></p>
 <script src="options.js"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+<meta charset="UTF-8">
+<title>Testudo instellingen</title>
+<style>
+  body{font-family:sans-serif;margin:20px;}
+  label{display:block;margin:5px 0;}
+</style>
+</head>
+<body>
+<h1>Onderwerpen verbergen</h1>
+<form id="categories">
+  <label><input type="checkbox" name="violence"> Geweld</label>
+  <label><input type="checkbox" name="sexual"> Zedenzaken</label>
+  <label><input type="checkbox" name="corruption"> Corruptie</label>
+</form>
+<button id="save">Opslaan</button>
+<p id="status"></p>
+<script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,26 @@
+const defaults = { violence: true, sexual: true, corruption: true };
+
+function restore() {
+  chrome.storage.sync.get(defaults, items => {
+    Object.keys(defaults).forEach(key => {
+      const input = document.querySelector(`input[name="${key}"]`);
+      if (input) input.checked = items[key];
+    });
+  });
+}
+
+function save() {
+  const data = {};
+  Object.keys(defaults).forEach(key => {
+    const input = document.querySelector(`input[name="${key}"]`);
+    if (input) data[key] = input.checked;
+  });
+  chrome.storage.sync.set(data, () => {
+    const s = document.getElementById('status');
+    s.textContent = 'Instellingen opgeslagen';
+    setTimeout(() => s.textContent = '', 1000);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restore);
+document.getElementById('save').addEventListener('click', save);

--- a/options.js
+++ b/options.js
@@ -23,4 +23,7 @@ function save() {
 }
 
 document.addEventListener('DOMContentLoaded', restore);
-document.getElementById('save').addEventListener('click', save);
+document.getElementById('save').addEventListener('click', ev => {
+  ev.preventDefault();
+  save();
+});


### PR DESCRIPTION
## Summary
- categorize triggerwoorden in `content.js`
- voeg een optiespagina toe met checkboxes
- pas `manifest.json` aan om de optiespagina te registreren

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68529f13c12483238f2899cd5e98a82b